### PR TITLE
Allow setting the ID of the notification manually

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ addNotification(notification);
  
 | Property     | Type             | Default | Description |
 | ------------ | ---------------- | ------- | ----------- |
-| id           | Object           |         | ID of the notification. If not provided during creation, will be generated automatically using the current timestamp. |
+| id           | String or Number |         | ID of the notification. If not provided during creation, will be generated automatically using the current timestamp. |
 | title        | String           |         | Title of the notification |
 | message      | String           |         | Message of the notification |
 | image        | String           |         | URL of an image. When an image is defined, status of the notification is set to `default`. |
@@ -114,13 +114,13 @@ updateNotification(notification);
 
 | Parameter    | Type     | Description |
 | ------------ | -------- | ----------- |
-| notification | Object   | A [notification](https://github.com/LouisBarranqueiro/reapop/blob/master/docs/api.md#notification-object-properties-1) object or ID of the notification |
+| notification | Object   | A [notification](https://github.com/LouisBarranqueiro/reapop/blob/master/docs/api.md#notification-object-properties-1) object |
 
 #### Notification object properties
  
 | Property     | Type             | Default | Description |
 | ------------ | ---------------- | ------- | ----------- |
-| id           | Object           |         | ID of the notification.  |
+| id           | String or Number |         | ID of the notification.  |
 | title        | String           |         | Title of the notification |
 | message      | String           |         | Message of the notification |
 | image        | String           |         | URL of an image. When an image is defined, status of the notification is set to `default`. |
@@ -178,7 +178,7 @@ removeNotification(id);
 
 | Parameter   | Type   | Description |
 | ----------- | ------ | ----------- |
-| id          | Object | ID of the notification |
+| id          | String or Number | ID of the notification |
 
 ## Theme
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,7 @@ addNotification(notification);
  
 | Property     | Type             | Default | Description |
 | ------------ | ---------------- | ------- | ----------- |
+| id           | Object           |         | ID of the notification. If not provided during creation, will be generated automatically using the current timestamp. |
 | title        | String           |         | Title of the notification |
 | message      | String           |         | Message of the notification |
 | image        | String           |         | URL of an image. When an image is defined, status of the notification is set to `default`. |
@@ -113,12 +114,13 @@ updateNotification(notification);
 
 | Parameter    | Type     | Description |
 | ------------ | -------- | ----------- |
-| notification | Object   | A [notification](https://github.com/LouisBarranqueiro/reapop/blob/master/docs/api.md#notification-object-properties-1) object |
+| notification | Object   | A [notification](https://github.com/LouisBarranqueiro/reapop/blob/master/docs/api.md#notification-object-properties-1) object or ID of the notification |
 
 #### Notification object properties
  
 | Property     | Type             | Default | Description |
 | ------------ | ---------------- | ------- | ----------- |
+| id           | Object           |         | ID of the notification.  |
 | title        | String           |         | Title of the notification |
 | message      | String           |         | Message of the notification |
 | image        | String           |         | URL of an image. When an image is defined, status of the notification is set to `default`. |
@@ -176,7 +178,7 @@ removeNotification(id);
 
 | Parameter   | Type   | Description |
 | ----------- | ------ | ----------- |
-| id          | Number | id of the notification |
+| id          | Object | ID of the notification |
 
 ## Theme
 

--- a/src/store/notifications.js
+++ b/src/store/notifications.js
@@ -17,7 +17,9 @@ const REMOVE_NOTIFICATION = 'REMOVE_NOTIFICATION';
  * @returns {Object} notification
  */
 export const addNotification = (notification) => (dispatch) => {
-  notification.id = new Date().getTime();
+  if (notification.id === undefined) {
+    notification.id = new Date().getTime();
+  }
   notification = treatNotification(notification);
   // if there is an image, we preload it
   // and add notification when image is loaded

--- a/src/store/notifications.js
+++ b/src/store/notifications.js
@@ -17,7 +17,7 @@ const REMOVE_NOTIFICATION = 'REMOVE_NOTIFICATION';
  * @returns {Object} notification
  */
 export const addNotification = (notification) => (dispatch) => {
-  if (notification.id === undefined) {
+  if (!notification.id) {
     notification.id = new Date().getTime();
   }
   notification = treatNotification(notification);

--- a/test/store/notifications.test.js
+++ b/test/store/notifications.test.js
@@ -24,7 +24,28 @@ describe('notifications', () => {
       });
 
       it('should create an action to add a notification ' +
-        '(add `id` property and convert status)', () => {
+        '(add `id` property if not given and convert status)', () => {
+        const customId = 'ACTION_ID';
+        notification.id = customId;
+        // we remove the image, otherwise `treatNotification()` helper will update
+        // status of notification
+        notification.image = null;
+        // here we simulate an HTTP success status code (200 = OK)
+        notification.status = 200;
+        const notificationAdded = store.dispatch(addNotification(notification));
+        const expectedAction = [{
+          type: types.ADD_NOTIFICATION,
+          payload: Object.assign({}, notification, {
+            id: notificationAdded.id,
+            status: SUCCESS_STATUS
+          })
+        }];
+        expect(notificationAdded.id).toEqual(customId);
+        expect(store.getActions()).toEqual(expectedAction);
+      });
+
+      it('should create an action to add a notification ' +
+        '(and convert status)', () => {
         notification.id = null;
         // we remove the image, otherwise `treatNotification()` helper will update
         // status of notification


### PR DESCRIPTION
This PR allows to set manually the identifier of the notification. The uniqueness of the ID in this case is the responsibility of the user. This does not change any existing behaviour.

Made for this issue: https://github.com/LouisBarranqueiro/reapop/issues/6

I am not sure on where to add the documentation about this feature, please point me
