### PR TITLE
Default settings on redux part

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const createStoreWithMiddleware = compose(
 )(createStore);
 const store = createStoreWithMiddleware(combineReducers({
     // reducer must be mounted as `notifications` !
-    notifications: notificationsReducer
+    notifications: notificationsReducer()
     // your reducers here
   }), {});
 ```

--- a/demo/src/components/Demo/index.js
+++ b/demo/src/components/Demo/index.js
@@ -46,7 +46,7 @@ class Demo extends Component {
     const {notify, updateNotification} = this.props;
 
     window.addEventListener('resize', this._updateWindowWidth);
-    let notif = notify({
+    const notif = notify({
       title: 'Welcome on demo!',
       message: 'Hey buddy, here you can see what you can do with it.',
       status: 'info',

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -11,7 +11,7 @@ import './styles/style.scss';
 // store
 const createStoreWithMiddleware = compose(applyMiddleware(thunk))(createStore);
 const store = createStoreWithMiddleware(combineReducers({
-  notifications: notificationsReducer
+  notifications: notificationsReducer()
 }), {});
 
 // render

--- a/docs/api.md
+++ b/docs/api.md
@@ -181,6 +181,29 @@ removeNotification(id);
 | ----------- | ------ | ----------- |
 | id          | String or Number | ID of the notification |
 
+### Remove all notifications
+
+Removing all notifications is done with `removeNotifications` (action creator) function.
+
+#### Syntax
+
+``` js
+removeNotifications();
+```
+
+## Customize default values for notifications
+
+You can customizable default values for notifications, by passing an object to the notification reducer.
+
+| Property     | Type    | Default | Description |
+| ------------ | ------- | ------- | ----------- |
+| status       | String  | null    | Status of the notification : default, info, success, warning, error. These values are available in `STATUS` variable. See [code](https://github.com/LouisBarranqueiro/reapop/blob/master/src/constants/index.js) |
+| position     | String  | tr      | Position of the notification : `t`, `tc`, `tl`, `tr`, `b`, `bc`, `br`, `bl`.  These values are available in `POSITIONS` variable. See [code](https://github.com/LouisBarranqueiro/reapop/blob/master/src/constants/index.js) |
+| dismissible  | Boolean | true    | Define if the notification is dismissible by clicking on it |
+| dismissAfter | Number  | 5000    | Time before the notification disappear (ms). 0: infinite |
+| closeButton  | Boolean | False   | Display a close button if notification is dismissible |
+| allowHTML    | Boolean | False   | Allow HTML in title and message of the notification. Read [this](https://facebook.github.io/react/tips/dangerously-set-inner-html.html) before setting this value to true. |
+
 ## Theme
 
 ### Themes list
@@ -416,42 +439,32 @@ This object allow you to configure style of `Notification` component.
 
 Check [Notification.js](https://github.com/LouisBarranqueiro/reapop/tree/master/src/components/Notification.js) file to see the JSX structure of `Notification` component.
 
-## Customize default values for notifications
-
-You can customizable default values for notifications, by passing an object to `defaultValues` props of `NotificationsSystem` component.
-
-| Property     | Type    | Default | Description |
-| ------------ | ------- | ------- | ----------- |
-| status       | String  | null    | Status of the notification : default, info, success, warning, error. These values are available in `STATUS` variable. See [code](https://github.com/LouisBarranqueiro/reapop/blob/master/src/constants/index.js) |
-| position     | String  | tr      | Position of the notification : `t`, `tc`, `tl`, `tr`, `b`, `bc`, `br`, `bl`.  These values are available in `POSITIONS` variable. See [code](https://github.com/LouisBarranqueiro/reapop/blob/master/src/constants/index.js) |
-| dismissible  | Boolean | true    | Define if the notification is dismissible by clicking on it |
-| dismissAfter | Number  | 5000    | Time before the notification disappear (ms). 0: infinite |
-| closeButton  | Boolean | False   | Display a close button if notification is dismissible |
-| allowHTML    | Boolean | False   | Allow HTML in title and message of the notification. Read [this](https://facebook.github.io/react/tips/dangerously-set-inner-html.html) before setting this value to true. |
-
 #### Example
 
 ``` js 
-import React, {Component} from 'react';
-// STATUS contains all available status
-// POSITIONS contains all available positions
-import NotificationsSystem, {STATUS, POSITIONS} from 'reapop';
+import {createStore, compose, applyMiddleware} from 'redux';
+import thunk from 'redux-thunk';
+import {reducer as notificationsReducer} from 'reapop';
 
-class AComponent extends Component {
-  render() {
-    const defaultValues = {
-      status: STATUS.default,
-      position: POSITIONS.topRight,
-      dismissible: true,
-      dismissAfter: 5000,
-      closeButton: true,
-      allowHTML: false
-    };
-    return (
-      <NotificationsSystem defaultValues={defaultValues}/>
-    );
-  }
-}
+// default value for notifications
+const defaultNotification = {
+        status: 'info',
+        position: 'tr',
+        dismissible: true,
+        dismissAfter: 2000,
+        allowHTML: true,
+        closeButton: true
+      };
+
+// store
+const createStoreWithMiddleware = compose(
+  applyMiddleware(thunk)
+)(createStore);
+const store = createStoreWithMiddleware(combineReducers({
+    // reducer must be mounted as `notifications` !
+    notifications: notificationsReducer(defaultNotification) // pass config here
+    // your reducers here
+  }), {});
 ```
 
 #### Integrate and customize a theme in your project

--- a/src/components/NotificationsContainer.js
+++ b/src/components/NotificationsContainer.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import TransitionGroup from 'react/lib/ReactCSSTransitionGroup';
-import {mapObjectValues} from '../helpers';
 import Notification from './Notification';
 import {POSITIONS} from '../constants';
 
@@ -14,14 +13,6 @@ export class NotificationsContainer extends Component {
   static propTypes = {
     notifications: React.PropTypes.array.isRequired,
     position: React.PropTypes.string.isRequired,
-    defaultValues: React.PropTypes.shape({
-      status: React.PropTypes.string.isRequired,
-      position: React.PropTypes.oneOf(mapObjectValues(POSITIONS)),
-      dismissible: React.PropTypes.bool.isRequired,
-      dismissAfter: React.PropTypes.number.isRequired,
-      closeButton: React.PropTypes.bool.isRequired,
-      allowHTML: React.PropTypes.bool.isRequired
-    }).isRequired,
     theme: React.PropTypes.shape({
       notificationsContainer: React.PropTypes.shape({
         className: React.PropTypes.shape({
@@ -39,7 +30,7 @@ export class NotificationsContainer extends Component {
       }).isRequired
     }).isRequired
   };
-  
+
   /**
    * Constructor
    * Bind methods
@@ -50,7 +41,7 @@ export class NotificationsContainer extends Component {
     super(props);
     this._renderNotifications = this._renderNotifications.bind(this);
   }
-  
+
   /**
    * Render notifications
    * @private
@@ -59,8 +50,10 @@ export class NotificationsContainer extends Component {
   _renderNotifications() {
     // get all notifications and default values for notifications
     const {
-      position, theme: {notification: {className}},
-      defaultValues: {status, dismissible, dismissAfter, closeButton, allowHTML}
+      position,
+      theme: {
+        notification: {className}
+      }
     } = this.props;
     let {notifications} = this.props;
 
@@ -71,29 +64,11 @@ export class NotificationsContainer extends Component {
       notifications = notifications.reverse();
     }
 
-    return notifications.map((notification) => {
-      // Define default values for notification if it's needed
-      if (!notification.status) {
-        notification.status = status;
-      }
-      if (typeof notification.dismissible !== 'boolean') {
-        notification.dismissible = dismissible;
-      }
-      if (typeof notification.dismissAfter !== 'number') {
-        notification.dismissAfter = dismissAfter;
-      }
-      if (typeof notification.closeButton !== 'boolean') {
-        notification.closeButton = closeButton;
-      }
-      if (typeof notification.allowHTML !== 'boolean') {
-        notification.allowHTML = allowHTML;
-      }
-      return (
-        <Notification key={notification.id} notification={notification} className={className}/>
-      );
-    });
+    return notifications.map((notification) => (
+      <Notification key={notification.id} notification={notification} className={className}/>
+    ));
   }
-  
+
   /**
    * Render
    * @returns {XML}
@@ -106,7 +81,9 @@ export class NotificationsContainer extends Component {
 
     return (
       <div className={`${className.main} ${className.position(position)}`}>
-        <TransitionGroup transitionName={name} transitionEnterTimeout={enterTimeout}
+        <TransitionGroup
+          transitionName={name}
+          transitionEnterTimeout={enterTimeout}
           transitionLeaveTimeout={leaveTimeout}>
           {this._renderNotifications()}
         </TransitionGroup>

--- a/src/components/NotificationsSystem.js
+++ b/src/components/NotificationsSystem.js
@@ -2,29 +2,17 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {mapObjectValues} from '../helpers';
 import NotificationsContainer from './NotificationsContainer';
-import {STATUS, POSITIONS} from '../constants';
-
-// default value for notifications
-export const defaultValues = {
-  status: STATUS.default,
-  position: POSITIONS.topRight,
-  dismissible: true,
-  dismissAfter: 5000,
-  allowHTML: false,
-  closeButton: false
-};
+import {POSITIONS} from '../constants';
 
 export class NotificationsSystem extends Component {
   // default properties
   static defaultProps = {
-    notifications: [],
-    defaultValues
+    notifications: []
   };
   
   // properties types
   static propTypes = {
     notifications: React.PropTypes.array.isRequired,
-    defaultValues: React.PropTypes.object.isRequired,
     theme: React.PropTypes.shape({
       smallScreenMin: React.PropTypes.number.isRequired,
       notificationsSystem: React.PropTypes.shape({
@@ -73,38 +61,27 @@ export class NotificationsSystem extends Component {
    * @private
    */
   _renderNotificationsContainers() {
-    const {notifications, defaultValues, theme} = this.props;
-    const {position} = defaultValues;
+    const {notifications, theme} = this.props;
     const {windowWidth} = this.state;
+    const positions = mapObjectValues(POSITIONS);
+    const containers = []
+
     // render all notifications in the same container at the top for small screens
     if (windowWidth < theme.smallScreenMin) {
       return (
-        <NotificationsContainer key='t' position='t' defaultValues={defaultValues}
-          theme={theme} notifications={notifications}/>
+        <NotificationsContainer key='t' position='t' theme={theme} notifications={notifications}/>
       );
     }
-    let positions = mapObjectValues(POSITIONS);
-    // extract the default position of all positions
-    positions.splice(positions.indexOf(position), 1);
-    let notifs = notifications.filter((notif) => {
-      return (!notif.position || notif.position === position);
-    });
-    // init array with all notifications with default position
-    let JSX = [
-      <NotificationsContainer key={position} position={position} defaultValues={defaultValues}
-        theme={theme} notifications={notifs}/>
-    ];
-    // fill array with others containers
-    JSX = JSX.concat(positions.map((position) => {
+
+    containers.push(positions.map((position) => {
       let notifs = notifications.filter((notif) => {
         return position === notif.position;
       });
       return (
-        <NotificationsContainer key={position} position={position} defaultValues={defaultValues}
-          theme={theme} notifications={notifs}/>
+        <NotificationsContainer key={position} position={position} theme={theme} notifications={notifs}/>
       );
     }));
-    return JSX;
+    return containers;
   }
   
   /**

--- a/src/components/NotificationsSystem.js
+++ b/src/components/NotificationsSystem.js
@@ -64,7 +64,7 @@ export class NotificationsSystem extends Component {
     const {notifications, theme} = this.props;
     const {windowWidth} = this.state;
     const positions = mapObjectValues(POSITIONS);
-    const containers = []
+    const containers = [];
 
     // render all notifications in the same container at the top for small screens
     if (windowWidth < theme.smallScreenMin) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -31,3 +31,13 @@ export const POSITIONS = {
   bottomLeft: BOTTOM_LEFT_POSITION,
   bottomRight: BOTTOM_RIGHT_POSITION
 };
+
+// default value for notifications
+export const DEFAULT_NOTIFICATION = {
+  status: DEFAULT_STATUS,
+  position: TOP_RIGHT_POSITION,
+  dismissible: true,
+  dismissAfter: 5000,
+  allowHTML: false,
+  closeButton: false
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -23,8 +23,8 @@ export function convertStatus(status) {
 
 /**
  * Create a Timer
- * @param {Function} callback
  * @param {Number} delay
+ * @param {Function} callback
  * @constructor
  */
 export function Timer(delay, callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import NotificationsSystem from './components/NotificationsSystem';
-import {STATUS, POSITIONS} from './constants';
+import {STATUS, POSITIONS, DEFAULT_NOTIFICATION} from './constants';
 import reducer, {
   actions,
   types,
@@ -11,6 +11,8 @@ import reducer, {
 
 export {
   // constants
+  // default value for notifications
+  DEFAULT_NOTIFICATION,
   // all available status
   STATUS,
   // all available positions

--- a/src/store/notifications.js
+++ b/src/store/notifications.js
@@ -1,4 +1,5 @@
 import {treatNotification, preloadImage} from '../helpers';
+import {DEFAULT_NOTIFICATION} from '../constants';
 
 // An array to store notifications object
 const INITIAL_STATE = [];
@@ -132,21 +133,24 @@ export const types = {
 };
 
 // Reducers
-export default (state = INITIAL_STATE, {type, payload}) => {
-  switch (type) {
-    case ADD_NOTIFICATION:
-      return [...state, payload];
-    case UPDATE_NOTIFICATION:
-      // get index of the notification
-      const index = state.findIndex((notification) => notification.id === payload.id);
-      // replace the old notification by the new one
-      state[index] = Object.assign({}, payload);
-      return [...state];
-    case REMOVE_NOTIFICATION:
-      return state.filter((notification) => notification.id !== payload);
-    case REMOVE_NOTIFICATIONS:
-      return [];
-    default:
-      return state;
-  }
+export default (defaultNotification = DEFAULT_NOTIFICATION) => {
+  return (state = INITIAL_STATE, {type, payload}) => {
+    switch (type) {
+      case ADD_NOTIFICATION:
+        const notification = Object.assign({}, defaultNotification, payload);
+        return [...state, notification];
+      case UPDATE_NOTIFICATION:
+        // get index of the notification
+        const index = state.findIndex((notification) => notification.id === payload.id);
+        // replace the old notification by the new one
+        state[index] = Object.assign({}, payload);
+        return [...state];
+      case REMOVE_NOTIFICATION:
+        return state.filter((notification) => notification.id !== payload);
+      case REMOVE_NOTIFICATIONS:
+        return [];
+      default:
+        return state;
+    }
+  };
 };

--- a/src/store/notifications.js
+++ b/src/store/notifications.js
@@ -143,7 +143,7 @@ export default (defaultNotification = DEFAULT_NOTIFICATION) => {
         // get index of the notification
         const index = state.findIndex((notification) => notification.id === payload.id);
         // replace the old notification by the new one
-        state[index] = Object.assign({}, payload);
+        state[index] = Object.assign({}, defaultNotification, payload);
         return [...state];
       case REMOVE_NOTIFICATION:
         return state.filter((notification) => notification.id !== payload);

--- a/test/components/Notification.test.js
+++ b/test/components/Notification.test.js
@@ -381,7 +381,7 @@ describe('<Notification/>', () => {
 
   it('should not create an action to remove the notification ' +
     'while mouse is hovering it', (done) => {
-    notification.dismissAfter = 10;
+    notification.dismissAfter = 100;
     notification.buttons = [];
     const wrapper = mount(
       <Provider store={store}>
@@ -395,19 +395,19 @@ describe('<Notification/>', () => {
     // hover notification after 5s
     setTimeout(() => {
       wrapper.simulate('mouseEnter');
-    }, 5);
+    }, 50);
     // check 5ms after `dismissAfter` duration that the store
     // is empty because mouse is hovering the notification
     setTimeout(() => {
       expect(store.getActions()).toEqual([]);
       // we leave notification
       wrapper.simulate('mouseLeave');
-    }, 15);
+    }, 150);
     // and we check that the store contains an action
     setTimeout(() => {
       expect(store.getActions()).toEqual([expectedAction]);
       done();
-    }, 21);
+    }, 210);
   });
   
   it('should not create an action to remove the notification ' +

--- a/test/components/NotificationsContainer.test.js
+++ b/test/components/NotificationsContainer.test.js
@@ -2,10 +2,8 @@ import React from 'react';
 import {Provider} from 'react-redux';
 import {mount, shallow} from 'enzyme';
 import {ExpectedNotificationsContainer} from '../utils/expectedComponents';
-import {mockStore, genNotification, genNotifications, checkPropTypes} from '../utils/fixtures';
+import {mockStore, genNotifications, checkPropTypes} from '../utils/fixtures';
 import NotificationsContainer from '../../src/components/NotificationsContainer';
-import {defaultValues} from '../../src/components/NotificationsSystem';
-import Notification from '../../src/components/Notification';
 import {POSITIONS} from '../../src/constants';
 import theme from 'reapop-theme-wybo';
 
@@ -13,8 +11,7 @@ describe('<NotificationsContainer/>', () => {
   let notifications = [];
   let store = null;
   const otherProps = {
-    theme,
-    defaultValues
+    theme
   };
 
   beforeEach('generate a new notification and init store', () => {
@@ -26,13 +23,11 @@ describe('<NotificationsContainer/>', () => {
     const errors = checkPropTypes({
       notifications: [],
       position: POSITIONS.topLeft,
-      defaultValues,
       theme
     }, NotificationsContainer.propTypes);
 
     expect(errors.notifications).toNotExist();
     expect(errors.position).toNotExist();
-    expect(errors.defaultValues).toNotExist();
     expect(errors.theme).toNotExist();
   });
 
@@ -40,7 +35,6 @@ describe('<NotificationsContainer/>', () => {
     const errors = checkPropTypes({}, NotificationsContainer.propTypes);
     expect(errors.notifications).toExist();
     expect(errors.position).toExist();
-    expect(errors.defaultValues).toExist();
     expect(errors.theme).toExist();
   });
 
@@ -80,34 +74,6 @@ describe('<NotificationsContainer/>', () => {
           {...otherProps}/>
       </Provider>
     );
-    expect(wrapper.html()).toEqual(expectedWrapper.html());
-  });
-
-  it('should render notification with default values for notifications', () => {
-    const notification = genNotification();
-    delete notification.status;
-    delete notification.dismissAfter;
-    delete notification.dismissible;
-    delete notification.closeButton;
-    delete notification.allowHTML;
-    const wrapper = mount(
-      <Provider store={store}>
-        <NotificationsContainer position={POSITIONS.bottomLeft} notifications={[notification]}
-          {...otherProps}/>
-      </Provider>
-    );
-    const expectedWrapper = mount(
-      <Provider store={store}>
-        <ExpectedNotificationsContainer position={POSITIONS.bottomLeft}
-          notifications={[notification]}
-          {...otherProps}/>
-      </Provider>
-    );
-    const props = wrapper.find(Notification).props();
-    expect(props.notification.status).toEqual(defaultValues.status);
-    expect(props.notification.dismissible).toEqual(defaultValues.dismissible);
-    expect(props.notification.dismissAfter).toEqual(defaultValues.dismissAfter);
-    expect(props.notification.allowHTML).toEqual(defaultValues.allowHTML);
     expect(wrapper.html()).toEqual(expectedWrapper.html());
   });
 

--- a/test/components/NotificationsSystem.test.js
+++ b/test/components/NotificationsSystem.test.js
@@ -2,14 +2,12 @@ import React from 'react';
 import {mount} from 'enzyme';
 import {Provider} from 'react-redux';
 import ConnectedNotificationsSystem, {
-  NotificationsSystem,
-  defaultValues
+  NotificationsSystem
 } from '../../src/components/NotificationsSystem';
 import Notification from '../../src/components/Notification';
 import NotificationsContainer from '../../src/components/NotificationsContainer';
 import {genNotifications, mockStore, checkPropTypes} from '../utils/fixtures';
 import {ExpectedNotificationsSystem} from '../utils/expectedComponents';
-import {STATUS, POSITIONS} from '../../src/constants';
 import theme from 'reapop-theme-wybo';
 
 describe('<NotificationsSystem/>', () => {
@@ -20,44 +18,22 @@ describe('<NotificationsSystem/>', () => {
   it('should validate props', () => {
     const errors = checkPropTypes({
       notifications: [],
-      theme,
-      defaultValues
+      theme
     }, NotificationsSystem.propTypes);
 
     expect(errors.notifications).toNotExist();
     expect(errors.theme).toNotExist();
-    expect(errors.defaultValues).toNotExist();
   });
 
   it('should not validate props', () => {
     const errors = checkPropTypes({}, NotificationsSystem.propTypes);
     expect(errors.notifications).toExist();
     expect(errors.theme).toExist();
-    expect(errors.defaultValues).toExist();
   });
 
   it('should mount with default props', () => {
     const props = mount(<NotificationsSystem {...otherProps}/>).props();
     expect(props.notifications).toEqual([]);
-    expect(props.defaultValues).toEqual(defaultValues);
-  });
-
-  it('should mount with custom props', () => {
-    const customDefaultValue = {
-      status: STATUS.success,
-      position: POSITIONS.bottomRight,
-      dismissible: false,
-      dismissAfter: 99999,
-      allowHTML: true
-    };
-    const wrapper = mount(<NotificationsSystem
-      defaultValues={customDefaultValue} {...otherProps}/>);
-    const props = wrapper.props();
-    expect(props.defaultValues).toEqual(customDefaultValue);
-    expect(props.defaultValues).toNotEqual(defaultValues);
-    const containerProps = wrapper.find(NotificationsContainer).props();
-    expect(containerProps.defaultValues).toEqual(customDefaultValue);
-    expect(containerProps.defaultValues).toNotEqual(defaultValues);
   });
 
   it('should render 1 empty notifications container (mobile)', () => {

--- a/test/store/notifications.test.js
+++ b/test/store/notifications.test.js
@@ -7,7 +7,7 @@ import reducer, {
   removeNotification,
   removeNotifications
 } from '../../src/store/notifications';
-import {SUCCESS_STATUS} from '../../src/constants';
+import {SUCCESS_STATUS, DEFAULT_NOTIFICATION, BOTTOM_CENTER} from '../../src/constants';
 
 describe('notifications', () => {
   let notification = null;
@@ -78,7 +78,7 @@ describe('notifications', () => {
           // image should be loaded now, so store should contains the notification updated
           expect(store.getActions()).toEqual(expectedAction);
           done();
-        }, 500);
+        }, 1000);
       });
 
       it('should create an action to add a notification ' +
@@ -196,28 +196,73 @@ describe('notifications', () => {
 
   describe('Reducers', () => {
     it('should return the initial state', () => {
-      expect(reducer(undefined, {})).toEqual([]);
+      expect(reducer()(undefined, {})).toEqual([]);
     });
 
     it('should handle ADD_NOTIFICATION', () => {
       const notification2 = genNotification();
       expect(
-        reducer([], {
+        reducer()([], {
           type: types.ADD_NOTIFICATION,
           payload: notification
         })
       ).toEqual([notification]);
+
       expect(
-        reducer([notification], {
+        reducer()([notification], {
           type: types.ADD_NOTIFICATION,
           payload: notification2
         })
       ).toEqual([notification, notification2]);
     });
 
+    it('should handle ADD_NOTIFICATION (default notification values)', () => {
+      delete notification.status;
+      delete notification.dismissAfter;
+      delete notification.dismissible;
+      delete notification.closeButton;
+      delete notification.allowHTML;
+      const notif = reducer()([], {
+        type: types.ADD_NOTIFICATION,
+        payload: notification
+      })[0];
+
+      expect(notif.status).toEqual(DEFAULT_NOTIFICATION.status);
+      expect(notif.dismissAfter).toEqual(DEFAULT_NOTIFICATION.dismissAfter);
+      expect(notif.dismissible).toEqual(DEFAULT_NOTIFICATION.dismissible);
+      expect(notif.closeButton).toEqual(DEFAULT_NOTIFICATION.closeButton);
+      expect(notif.allowHTML).toEqual(DEFAULT_NOTIFICATION.allowHTML);
+    });
+
+    it('should handle ADD_NOTIFICATION (custom notification values)', () => {
+      const customValue = {
+        status: SUCCESS_STATUS,
+        position: BOTTOM_CENTER,
+        dismissible: false,
+        dismissAfter: 2333,
+        allowHTML: true,
+        closeButton: true
+      };
+      delete notification.status;
+      delete notification.dismissAfter;
+      delete notification.dismissible;
+      delete notification.closeButton;
+      delete notification.allowHTML;
+      const notif = reducer(customValue)([], {
+        type: types.ADD_NOTIFICATION,
+        payload: notification
+      })[0];
+
+      expect(notif.status).toEqual(customValue.status);
+      expect(notif.dismissAfter).toEqual(customValue.dismissAfter);
+      expect(notif.dismissible).toEqual(customValue.dismissible);
+      expect(notif.closeButton).toEqual(customValue.closeButton);
+      expect(notif.allowHTML).toEqual(customValue.allowHTML);
+    });
+
     it('should handle UPDATE_NOTIFICATION', () => {
       expect(
-        reducer([notification], {
+        reducer()([notification], {
           type: types.UPDATE_NOTIFICATION,
           payload: notification
         })
@@ -226,7 +271,7 @@ describe('notifications', () => {
 
     it('should handle REMOVE_NOTIFICATION', () => {
       expect(
-        reducer([notification], {
+        reducer()([notification], {
           type: types.REMOVE_NOTIFICATION,
           payload: notification.id
         })
@@ -235,7 +280,7 @@ describe('notifications', () => {
 
     it('should handle REMOVE_NOTIFICATIONS', () => {
       expect(
-        reducer([notification], {
+        reducer()([notification], {
           type: types.REMOVE_NOTIFICATIONS
         })
       ).toEqual([]);

--- a/test/store/notifications.test.js
+++ b/test/store/notifications.test.js
@@ -269,6 +269,50 @@ describe('notifications', () => {
       ).toEqual([notification]);
     });
 
+    it('should handle UPDATE_NOTIFICATION (default notification values)', () => {
+      delete notification.status;
+      delete notification.dismissAfter;
+      delete notification.dismissible;
+      delete notification.closeButton;
+      delete notification.allowHTML;
+      const notif = reducer()([notification], {
+        type: types.UPDATE_NOTIFICATION,
+        payload: notification
+      })[0];
+
+      expect(notif.status).toEqual(DEFAULT_NOTIFICATION.status);
+      expect(notif.dismissAfter).toEqual(DEFAULT_NOTIFICATION.dismissAfter);
+      expect(notif.dismissible).toEqual(DEFAULT_NOTIFICATION.dismissible);
+      expect(notif.closeButton).toEqual(DEFAULT_NOTIFICATION.closeButton);
+      expect(notif.allowHTML).toEqual(DEFAULT_NOTIFICATION.allowHTML);
+    });
+
+    it('should handle UPDATE_NOTIFICATION (custom notification values)', () => {
+      const customValue = {
+        status: SUCCESS_STATUS,
+        position: BOTTOM_CENTER,
+        dismissible: false,
+        dismissAfter: 2333,
+        allowHTML: true,
+        closeButton: true
+      };
+      delete notification.status;
+      delete notification.dismissAfter;
+      delete notification.dismissible;
+      delete notification.closeButton;
+      delete notification.allowHTML;
+      const notif = reducer(customValue)([notification], {
+        type: types.UPDATE_NOTIFICATION,
+        payload: notification
+      })[0];
+
+      expect(notif.status).toEqual(customValue.status);
+      expect(notif.dismissAfter).toEqual(customValue.dismissAfter);
+      expect(notif.dismissible).toEqual(customValue.dismissible);
+      expect(notif.closeButton).toEqual(customValue.closeButton);
+      expect(notif.allowHTML).toEqual(customValue.allowHTML);
+    });
+
     it('should handle REMOVE_NOTIFICATION', () => {
       expect(
         reducer()([notification], {

--- a/test/utils/expectedComponents.js
+++ b/test/utils/expectedComponents.js
@@ -1,10 +1,9 @@
 import React, {Component} from 'react';
-import _ from 'lodash';
+import {mapObjectValues} from '../../src/helpers';
 import TransitionGroup from 'react/lib/ReactCSSTransitionGroup';
 import {POSITIONS} from '../../src/constants';
 import Notification from '../../src/components/Notification';
 import NotificationsContainer from '../../src/components/NotificationsContainer';
-import {defaultValues} from '../../src/components/NotificationsSystem';
 
 // We use these "expected" component to test HTML structure of each components.
 // It's easier and faster than testing manually each nodes.
@@ -16,7 +15,7 @@ export class ExpectedNotification extends Component {
       __html: content
     };
   }
-  
+
   _renderButtons() {
     const {
       className,
@@ -36,7 +35,7 @@ export class ExpectedNotification extends Component {
       );
     });
   }
-  
+
   render() {
     const {
       className,
@@ -47,8 +46,8 @@ export class ExpectedNotification extends Component {
     return (
       <div className={className.wrapper}>
         <div className={`${className.main} ${className.status(status)} ` +
-          `${(isDismissible && !closeButton ? className.dismissible : '')} ` +
-          `${className.buttons(buttons.length)}`}>
+        `${(isDismissible && !closeButton ? className.dismissible : '')} ` +
+        `${className.buttons(buttons.length)}`}>
           {image ?
             <div className={className.imageContainer}>
               <span className={className.image} style={{backgroundImage: `url(${image})`}}/>
@@ -77,7 +76,7 @@ export class ExpectedNotification extends Component {
             <div className={className.buttons()}>
               {this._renderButtons()}
             </div> :
-          ''}
+            ''}
         </div>
       </div>
     );
@@ -88,8 +87,7 @@ export class ExpectedNotificationsContainer extends Component {
   _renderNotifications() {
     // get all notifications and default values for notifications
     const {
-      position, theme: {notification: {className}},
-      defaultValues: {status, dismissible, dismissAfter, closeButton, allowHTML}
+      position, theme: {notification: {className}}
     } = this.props;
     let {notifications} = this.props;
 
@@ -100,37 +98,24 @@ export class ExpectedNotificationsContainer extends Component {
     }
 
     return notifications.map((notification) => {
-      // Define default values for notification if it's needed
-      if (!notification.status) {
-        notification.status = status;
-      }
-      if (typeof notification.dismissible !== 'boolean') {
-        notification.dismissible = dismissible;
-      }
-      if (typeof notification.dismissAfter !== 'number') {
-        notification.dismissAfter = dismissAfter;
-      }
-      if (typeof notification.closeButton !== 'boolean') {
-        notification.closeButton = closeButton;
-      }
-      if (typeof notification.allowHTML !== 'boolean') {
-        notification.allowHTML = allowHTML;
-      }
       return (
         <Notification key={notification.id} notification={notification} className={className}/>
       );
     });
   }
-  
+
   render() {
     const {
-      className, transition: {name, enterTimeout, leaveTimeout}
+      className,
+      transition: {name, enterTimeout, leaveTimeout}
     } = this.props.theme.notificationsContainer;
     const {position} = this.props;
 
     return (
       <div className={`${className.main} ${className.position(position)}`}>
-        <TransitionGroup transitionName={name} transitionEnterTimeout={enterTimeout}
+        <TransitionGroup
+          transitionName={name}
+          transitionEnterTimeout={enterTimeout}
           transitionLeaveTimeout={leaveTimeout}>
           {this._renderNotifications()}
         </TransitionGroup>
@@ -141,41 +126,29 @@ export class ExpectedNotificationsContainer extends Component {
 
 export class ExpectedNotificationsSystem extends Component {
   static defaultProps = {
-    notifications: [],
-    defaultValues
+    notifications: []
   };
-
   _renderNotificationsContainers() {
-    const {notifications, defaultValues: {position}, theme} = this.props;
+    const {notifications, theme} = this.props;
+    const positions = mapObjectValues(POSITIONS);
+    const containers = [];
+
     // render all notifications in the same container at the top for small screens
     if (window.innerWidth < theme.smallScreenMin) {
       return (
-        <NotificationsContainer key='t' position='t' defaultValues={defaultValues}
-          theme={theme} notifications={notifications}/>
+        <NotificationsContainer key='t' position='t' theme={theme} notifications={notifications}/>
       );
     }
-    let positions = _.values(POSITIONS);
-    // extract the default position of all positions
-    positions.splice(positions.indexOf(position), 1);
-    let notifs = notifications.filter((notif) => {
-      return (!notif.position || notif.position === position);
-    });
-    // init array with all notifications with default position
-    let JSX = [
-      <NotificationsContainer key={position} position={position} defaultValues={defaultValues}
-        theme={theme} notifications={notifs}/>
-    ];
-    // fill array with others containers
-    JSX = JSX.concat(positions.map((position) => {
-      let notifs = notifications.filter((notif) => {
+
+    containers.push(positions.map((position) => {
+      const notifs = notifications.filter((notif) => {
         return position === notif.position;
       });
       return (
-        <NotificationsContainer key={position} position={position} defaultValues={defaultValues}
-          theme={theme} notifications={notifs}/>
+        <NotificationsContainer key={position} position={position} theme={theme} notifications={notifs}/>
       );
     }));
-    return JSX;
+    return containers;
   }
 
   render() {


### PR DESCRIPTION
### Changes proposed (features or fixes)

Now, default value for notification are configurable on the redux part, It allow to easily use your own react components to display notifications (less logic on view part).

### Checklist

 - [x] Don't forget to update README or API documentation if it's necessary
 - [x] Check code status with `npm run lint` 
 - [x] Run tests with `npm run test:all` 
 - [x] Launch demo with `npm start` to check the result in the browser. Check it on all possible browsers that you have and write them in the PR.
	 - [x] Chrome
	 - [x] Safari
	 - [x] Firefox
	 - [x] IE 10+
	 - [x] Edge
	 - [x] Opera