### PR TITLE
Allow string as notification id

### DIFF
--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import {connect} from 'react-redux';
 import {Timer, mapObjectValues} from '../helpers';
 import {removeNotification} from '../store/notifications';
@@ -20,44 +20,44 @@ function createTimer(dismissAfter, callback) {
 export class Notification extends Component {
   // Properties types
   static propTypes = {
-    className: React.PropTypes.shape({
-      main: React.PropTypes.string.isRequired,
-      wrapper: React.PropTypes.string.isRequired,
-      meta: React.PropTypes.string.isRequired,
-      title: React.PropTypes.string.isRequired,
-      message: React.PropTypes.string.isRequired,
-      imageContainer: React.PropTypes.string.isRequired,
-      image: React.PropTypes.string.isRequired,
-      icon: React.PropTypes.string.isRequired,
-      status: React.PropTypes.func.isRequired,
-      dismissible: React.PropTypes.string.isRequired,
-      closeButtonContainer: React.PropTypes.string.isRequired,
-      closeButton: React.PropTypes.string.isRequired,
-      buttons: React.PropTypes.func.isRequired,
-      button: React.PropTypes.string.isRequired,
-      buttonText: React.PropTypes.string.isRequired
+    className: PropTypes.shape({
+      main: PropTypes.string.isRequired,
+      wrapper: PropTypes.string.isRequired,
+      meta: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired,
+      imageContainer: PropTypes.string.isRequired,
+      image: PropTypes.string.isRequired,
+      icon: PropTypes.string.isRequired,
+      status: PropTypes.func.isRequired,
+      dismissible: PropTypes.string.isRequired,
+      closeButtonContainer: PropTypes.string.isRequired,
+      closeButton: PropTypes.string.isRequired,
+      buttons: PropTypes.func.isRequired,
+      button: PropTypes.string.isRequired,
+      buttonText: PropTypes.string.isRequired
     }).isRequired,
-    notification: React.PropTypes.shape({
-      id: React.PropTypes.number.isRequired,
-      title: React.PropTypes.string,
-      message: React.PropTypes.string,
-      image: React.PropTypes.string,
-      status: React.PropTypes.string.isRequired,
-      position: React.PropTypes.oneOf(mapObjectValues(POSITIONS)),
-      dismissAfter: React.PropTypes.number.isRequired,
-      dismissible: React.PropTypes.bool.isRequired,
-      onAdd: React.PropTypes.func,
-      onRemove: React.PropTypes.func,
-      closeButton: React.PropTypes.bool.isRequired,
-      buttons: React.PropTypes.arrayOf(
-        React.PropTypes.shape({
-          name: React.PropTypes.string.isRequired,
-          onClick: React.PropTypes.func
+    notification: PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+      title: PropTypes.string,
+      message: PropTypes.string,
+      image: PropTypes.string,
+      status: PropTypes.string.isRequired,
+      position: PropTypes.oneOf(mapObjectValues(POSITIONS)),
+      dismissAfter: PropTypes.number.isRequired,
+      dismissible: PropTypes.bool.isRequired,
+      onAdd: PropTypes.func,
+      onRemove: PropTypes.func,
+      closeButton: PropTypes.bool.isRequired,
+      buttons: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string.isRequired,
+          onClick: PropTypes.func
         })
       ).isRequired,
-      allowHTML: React.PropTypes.bool.isRequired
+      allowHTML: PropTypes.bool.isRequired
     }).isRequired,
-    removeNotification: React.PropTypes.func.isRequired
+    removeNotification: PropTypes.func.isRequired
   };
 
   /**


### PR DESCRIPTION
### Connects to #14

### Changes proposed (features or fixes)
Allow string as notification id

### Checklist

 - [x] Don't forget to update README or API documentation if it's necessary
 - [x] Check code status with `npm run lint` 
 - [x] Run tests with `npm run test:all` 
 - [x] Launch demo with `npm start` to check the result in the browser. Check it on all possible browsers that you have and write them in the PR.
	 - [x] Chrome
	 - [x] Safari
	 - [x] Firefox
	 - [x] IE 10+
	 - [x] Edge
	 - [x] Opera
