### PR TITLE
add react-css-transition-group as npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,8 @@
     "webpack": "^1.13.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.10.0"
+  },
+  "dependencies": {
+    "react-addons-css-transition-group": "^15.4.1"
   }
 }

--- a/src/components/NotificationsContainer.js
+++ b/src/components/NotificationsContainer.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import TransitionGroup from 'react/lib/ReactCSSTransitionGroup';
+import TransitionGroup from 'react-addons-css-transition-group';
 import Notification from './Notification';
 import {POSITIONS} from '../constants';
 


### PR DESCRIPTION
### Connects to #18

### Changes proposed (features or fixes)

Add react-css-transition-group as npm dependency

### Checklist

 - [x] Don't forget to update README or API documentation if it's necessary
 - [x] Check code status with `npm run lint` 
 - [x] Run tests with `npm run test:all` 
 - [x] Launch demo with `npm start` to check the result in the browser. Check it on all possible browsers that you have and write them in the PR.
	 - [x] Chrome
	 - [x] Safari
	 - [x] Firefox
	 - [x] IE 10+
	 - [x] Edge
	 - [x] Opera