### PR TITLE
Fix deprecation warnings in React 15.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "webpack-hot-middleware": "^2.10.0"
   },
   "dependencies": {
-    "react-addons-css-transition-group": "^15.4.1"
+    "prop-types": "^15.5.8",
+    "react-transition-group": "^1.1.2"
   }
 }

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {Timer, mapObjectValues} from '../helpers';
 import {removeNotification} from '../store/notifications';

--- a/src/components/NotificationsContainer.js
+++ b/src/components/NotificationsContainer.js
@@ -1,25 +1,26 @@
 import React, {Component} from 'react';
-import TransitionGroup from 'react-addons-css-transition-group';
+import PropTypes from 'prop-types';
+import TransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import Notification from './Notification';
 
 export class NotificationsContainer extends Component {
   static propTypes = {
-    notifications: React.PropTypes.array.isRequired,
-    position: React.PropTypes.string.isRequired,
-    theme: React.PropTypes.shape({
-      notificationsContainer: React.PropTypes.shape({
-        className: React.PropTypes.shape({
-          main: React.PropTypes.string.isRequired,
-          position: React.PropTypes.func.isRequired
+    notifications: PropTypes.array.isRequired,
+    position: PropTypes.string.isRequired,
+    theme: PropTypes.shape({
+      notificationsContainer: PropTypes.shape({
+        className: PropTypes.shape({
+          main: PropTypes.string.isRequired,
+          position: PropTypes.func.isRequired
         }).isRequired,
-        transition: React.PropTypes.shape({
-          name: React.PropTypes.object.isRequired,
-          enterTimeout: React.PropTypes.number.isRequired,
-          leaveTimeout: React.PropTypes.number.isRequired
+        transition: PropTypes.shape({
+          name: PropTypes.object.isRequired,
+          enterTimeout: PropTypes.number.isRequired,
+          leaveTimeout: PropTypes.number.isRequired
         }).isRequired
       }).isRequired,
-      notification: React.PropTypes.shape({
-        className: React.PropTypes.object.isRequired
+      notification: PropTypes.shape({
+        className: PropTypes.object.isRequired
       }).isRequired
     }).isRequired
   };

--- a/src/components/NotificationsSystem.js
+++ b/src/components/NotificationsSystem.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {mapObjectValues} from '../helpers';
 import NotificationsContainer from './NotificationsContainer';
@@ -6,11 +7,11 @@ import {POSITIONS} from '../constants';
 
 export class NotificationsSystem extends Component {
   static propTypes = {
-    notifications: React.PropTypes.array.isRequired,
-    theme: React.PropTypes.shape({
-      smallScreenMin: React.PropTypes.number.isRequired,
-      notificationsSystem: React.PropTypes.shape({
-        className: React.PropTypes.string
+    notifications: PropTypes.array.isRequired,
+    theme: PropTypes.shape({
+      smallScreenMin: PropTypes.number.isRequired,
+      notificationsSystem: PropTypes.shape({
+        className: PropTypes.string
       })
     }).isRequired
   };
@@ -86,7 +87,7 @@ export class NotificationsSystem extends Component {
     }));
     return containers;
   };
-  
+
   /**
    * Render
    * @returns {XML}

--- a/test/utils/expectedComponents.js
+++ b/test/utils/expectedComponents.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {mapObjectValues} from '../../src/helpers';
-import TransitionGroup from 'react/lib/ReactCSSTransitionGroup';
+import TransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import {POSITIONS} from '../../src/constants';
 import Notification from '../../src/components/Notification';
 import NotificationsContainer from '../../src/components/NotificationsContainer';


### PR DESCRIPTION
### Connects to #34 

### Changes proposed (features or fixes)
I've update the components to use the new `prop-types` package to validate PropTypes instead of those included in the main `react` package that has been deprecated starting from version 15.5. Also took the chance and dumped the [soon to be deprecated react-addons-css-transition-group](https://github.com/facebook/react/issues/8125) with the drop-in replacement `react-transition-group`


### How to test
Just use the library test's suite


### Checklist

 - [x] Don't forget to update README or API documentation if it's necessary
 - [x] Check code status with `npm run lint` 
 - [x] Run tests with `npm run test:all` 
 - [x] Launch demo with `npm start` to check the result in the browser. Check it on all possible browsers that you have and write them in the PR.
	 - [x] Chrome
	 - [x] Safari
	 - [x] Firefox
	 - [x] IE 10+
	 - [x] Edge
	 - [x] Opera
