### PR TITLE
Bring back PropTypes from 'prop-types' package

### DIFF
--- a/src/components/NotificationsSystem.js
+++ b/src/components/NotificationsSystem.js
@@ -7,16 +7,16 @@ import {POSITIONS} from '../constants';
 
 export class NotificationsSystem extends Component {
   static propTypes = {
-    notifications: React.PropTypes.array.isRequired,
+    notifications: PropTypes.array.isRequired,
     filter: PropTypes.func,
-    theme: React.PropTypes.shape({
-      smallScreenMin: React.PropTypes.number.isRequired,
-      smallScreenPosition: React.PropTypes.oneOf([
+    theme: PropTypes.shape({
+      smallScreenMin: PropTypes.number.isRequired,
+      smallScreenPosition: PropTypes.oneOf([
         POSITIONS.top,
         POSITIONS.bottom
       ]),
-      notificationsSystem: React.PropTypes.shape({
-        className: React.PropTypes.string
+      notificationsSystem: PropTypes.shape({
+        className: PropTypes.string
       })
     }).isRequired
   };


### PR DESCRIPTION
### Connects to #32 #34 
Wierd regression after issues/#32  was merged(#34 already fixed issue)
Reapop started to use React.PropTypes which will be deprecated
Minor change to proper use PropTypes
### Changes proposed (features or fixes)
Fixes


### How to test
This warning should disapear
https://www.dropbox.com/s/9j0wxo9xf34x5gd/Screenshot%202017-08-22%2013.40.03.png?dl=0

### Checklist

 - [x] Don't forget to update README or API documentation if it's necessary
       _no need_
 - [x] Check code status with `npm run lint` 
 - [x] Run tests with `npm run test:all` 
 - [x] Launch demo with `npm start` to check the result in the browser. Check it on all possible browsers that you have and write them in the PR.
	 - [x] Chrome
	 - [x] Safari
	 - [x] Firefox
	 - [x] IE 10+
	 - [x] Edge
	 - [x] Opera
