### PR TITLE
Use prop-types from library not React

### DIFF
--- a/src/components/NotificationsSystem.js
+++ b/src/components/NotificationsSystem.js
@@ -7,16 +7,16 @@ import {POSITIONS} from '../constants';
 
 export class NotificationsSystem extends Component {
   static propTypes = {
-    notifications: React.PropTypes.array.isRequired,
+    notifications: PropTypes.array.isRequired,
     filter: PropTypes.func,
-    theme: React.PropTypes.shape({
-      smallScreenMin: React.PropTypes.number.isRequired,
-      smallScreenPosition: React.PropTypes.oneOf([
+    theme: PropTypes.shape({
+      smallScreenMin: PropTypes.number.isRequired,
+      smallScreenPosition: PropTypes.oneOf([
         POSITIONS.top,
         POSITIONS.bottom
       ]),
-      notificationsSystem: React.PropTypes.shape({
-        className: React.PropTypes.string
+      notificationsSystem: PropTypes.shape({
+        className: PropTypes.string
       })
     }).isRequired
   };


### PR DESCRIPTION
This will remove warning:

```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
```