### PR TITLE
Fix link to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Read [API documentation](https://github.com/LouisBarranqueiro/reapop/blob/master
 
 ## Contributing guide
 
-Read [Contributing guide](https://github.com/LouisBarranqueiro/reapop/blob/master/.github/.CONTRIBUTING.md)
+Read [Contributing guide](https://github.com/LouisBarranqueiro/reapop/blob/master/.github/CONTRIBUTING.md)
 
 ## License 
 


### PR DESCRIPTION
I was searching for contribution guide and found small typo.