### PR TITLE
Fix warnings in react@16

### DIFF
--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -202,9 +202,9 @@ export class Notification extends Component {
     return (
       <div
         className={className.wrapper}
-        onClick={isDismissible && !closeButton ? this._remove : ''}
-        onMouseEnter={timer ? this._pauseTimer : ''}
-        onMouseLeave={timer ? this._resumeTimer : ''}
+        onClick={isDismissible && !closeButton ? this._remove : function() {}}
+        onMouseEnter={timer ? this._pauseTimer : function() {}}
+        onMouseLeave={timer ? this._resumeTimer : function() {}}
       >
         <div className={notificationClass}>
           {image


### PR DESCRIPTION
### Connects to #57 

### Changes proposed (features or fixes)

Use empty functions instead of strings to avoid warning in console since react@16

### How to test



### Checklist

 - [x] Don't forget to update README or API documentation if it's necessary
 - [x] Check code status with `npm run lint` 
 - [x] Run tests with `npm run test:all` 
 - [x] Launch demo with `npm start` to check the result in the browser. Check it on all possible browsers that you have and write them in the PR.
	 - [x] Chrome
	 - [ ] Safari
	 - [ ] Firefox
	 - [ ] IE 10+
	 - [ ] Edge
	 - [ ] Opera
