### PR TITLE
Use uuidv4 instead of timestamp for notification id.

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-transition-group": "^2.2.1"
+    "react-transition-group": "^2.2.1",
+    "uuid": "^3.3.2"
   }
 }

--- a/src/store/notifications.js
+++ b/src/store/notifications.js
@@ -1,3 +1,4 @@
+import uuidv4 from 'uuid/v4';
 import {treatNotification, preloadImage} from '../helpers';
 import {DEFAULT_NOTIFICATION} from '../constants';
 
@@ -19,7 +20,7 @@ const REMOVE_NOTIFICATIONS = 'REMOVE_NOTIFICATIONS';
  */
 export const addNotification = (notification) => (dispatch) => {
   if (!notification.id) {
-    notification.id = new Date().getTime();
+    notification.id = uuidv4();
   }
   notification = treatNotification(notification);
   // if there is an image, we preload it


### PR DESCRIPTION
While using a timestamp to generate a notification id can seem a natural choice, it's not a good idea.
In case of my app, I'm adding multiple notifications at once and sometimes they get the same id, i.e. they are generated at same millisecond.
The fix I propose uses RFC4122 standard compliant UUID [library](https://www.npmjs.com/package/uuid) to generate the unique id.

Passing all tests.
Tested in Chrome 67.