### PR TITLE
Fix IE support

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/es/map'
+import 'core-js/es/set'
+
 import React from 'react'
 import {Provider} from 'react-redux'
 import {render} from 'react-dom'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6027,6 +6027,12 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -6073,6 +6079,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -7008,9 +7020,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
+      "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-react": "7.12.5",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.1",
+    "core-js": "^3.7.0",
     "coveralls": "3.1.0",
     "css-loader": "2.1.1",
     "enzyme": "3.11.0",

--- a/src/components/NotificationsContainer.js
+++ b/src/components/NotificationsContainer.js
@@ -43,7 +43,7 @@ export class NotificationsContainer extends Component {
 
     // when notifications are displayed at the bottom,
     // we display notifications from bottom to top
-    if (position.startsWith('b')) {
+    if (position[0] === 'b') {
       notifications = notifications.reverse()
     }
 

--- a/src/store/notifications.js
+++ b/src/store/notifications.js
@@ -54,7 +54,7 @@ function _addNotification(notification) {
  */
 export const notify = (notification) => (dispatch, getState) => {
   const notifications = getState().notifications
-  const doesNotifExist = notifications.find(notif => notif.id === notification.id)
+  const doesNotifExist = notifications.some(notif => notif.id === notification.id)
 
   if (doesNotifExist) {
     return dispatch(updateNotification(notification))
@@ -153,13 +153,13 @@ export default (defaultNotification = DEFAULT_NOTIFICATION) => {
   return (state = INITIAL_STATE, {type, payload}) => {
     switch (type) {
       case ADD_NOTIFICATION: {
-        const notification = Object.assign({}, defaultNotification, payload)
+        const notification = {...defaultNotification, ...payload}
         return [...state, notification]
       }
       case UPDATE_NOTIFICATION:
         return state.map((notification) => {
           if (notification.id === payload.id) {
-            return Object.assign({}, defaultNotification, payload)
+            return {...defaultNotification, ...payload}
           }
           return notification
         })


### PR DESCRIPTION
### Related issues: <!-- If applicable: reference any related issues. E.g: #4515   --> 
### Changes
<!-- Describe and explain the changes you made. --> 
<!-- If applicable: add some screenshots --> 
Removed methods not supported in IE: `String#startsWith`, `Array#find`, `Object.assign`
Added `Map` & `Set` polyfills to demo as they're required by React 16: https://reactjs.org/docs/javascript-environment-requirements.html

### Testing guide
<!-- Describe the steps to test the changes made --> 
`npm run start` & open localhost:3000 in IE 10

### Checklist
- [x] I checked the code style with `npm run lint` 
- [x] I ran the tests with `npm run test:all` 
- [x] I added tests for the bug I fixed (if applicable)
- [ ] I updated the README or API documentation (if applicable)
- [ ] I updated the demo (if applicable)
- [ ] I verified my changes on all browsers listed below:
  - [ ] Chrome
  - [ ] Safari
  - [ ] Firefox
  - [x] IE 10+
  - [ ] Edge
  - [ ] Opera

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/reapop/307)
<!-- Reviewable:end -->
