### PR TITLE
Fix smallScreenBreakpoint prop

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -162,7 +162,7 @@ Components responsible for displaying notifications.
 | --------------------- | -------------- | ------- | ----------- |
 | notifications         | Notification[] |         | Notifications to be displayed |
 | dismissNotification   | Function       |         | Function responsible for dismissing a notification.
-| smallScreenBreakpoint | Function       | `768`   | Maximum window width under which all notifications will be positioned at top center of the screen no matter the `position` property of the notifications.
+| smallScreenBreakpoint | number         | `768`   | Maximum window width under which all notifications will be positioned at top center of the screen no matter the `position` property of the notifications.
 | components            | Object         | `{}`    | Custom components used to replace builtIn components. Customizable components: `Transition`, `NotificationIcon` and `Notification`
 | theme                 | Theme          |         | Theme used to display notifications. Available themes: `atalhoTheme`, `wyboTheme`, `bootstrapTheme`. You can also create your custom theme, or customize notifications with CSS files.
 

--- a/src/components/NotificationsSystem.tsx
+++ b/src/components/NotificationsSystem.tsx
@@ -17,7 +17,7 @@ export type Props = {
 }
 
 const NotificationsSystem = (props: Props) => {
-    const smallScreenBreakpoint = props.smallScreenBreakpoint || 768
+    const smallScreenBreakpoint = typeof props.smallScreenBreakpoint !== 'undefined' ? props.smallScreenBreakpoint : 768
     const theme = props.theme
     const components = props.components || {}
     const {notifications, dismissNotification} = props

--- a/src/components/tests/NotificationsSystem.spec.tsx
+++ b/src/components/tests/NotificationsSystem.spec.tsx
@@ -94,4 +94,46 @@ describe('<NotificationsSystem/>', () => {
         }
         expect(pretty(container.innerHTML)).toMatchSnapshot()
     })
+
+    it('should display a notification in any desired container if smallScreenBreakpoint is disabled', () => {
+        const windowInitialHeight = window.innerHeight
+        const windowInitialWidth = window.innerWidth
+
+        act(() => {
+            window.resizeTo(100, 100)
+        })
+
+        const desiredContainer = 'bottom-center'
+        const oneNotification: Notification[] = [
+            {
+                id: '0',
+                position: desiredContainer,
+                message: 'hello world!',
+                status: STATUSES.info,
+                buttons: [],
+            },
+        ]
+
+        const {container} = render(
+            <NotificationsSystem
+                notifications={oneNotification}
+                dismissNotification={jest.fn()}
+                smallScreenBreakpoint={0}
+            />
+        )
+
+        const oneContainer = container.querySelector(`.reapop__container--${desiredContainer}`)
+        if (oneContainer) {
+            expect(oneContainer.children).toHaveLength(1)
+        }
+        const fallbackContainer = container.querySelector('.reapop__container--top-center')
+        if (fallbackContainer) {
+            expect(fallbackContainer.children).toHaveLength(0)
+        }
+
+        act(() => {
+            // resize window back to its initial size
+            window.resizeTo(windowInitialWidth, windowInitialHeight)
+        })
+    })
 })


### PR DESCRIPTION
### Changes

Goal: For a mobile-focused web app, I want to display a Reapop notification at the bottom center of my screen, above my app tab bar.

It seemed logical to set `smallScreenBreakpoint` to `0` to disable the option of only having the top-center position but I found that the `NotificationsSystem` component does a basic or (`||`) operator so if `smallScreenBreakpoint` is falsey it will fallback to the default `768`.

I could set the prop to `1` or some other small number but I decided that contributing this PR would be beneficial so that it's clear to others that Reapop's breakpoint system can be disabled!

### Testing guide

I've added a new test `should display a notification in any desired container if smallScreenBreakpoint is disabled`.

> Note about the tests in this repo: You shouldn't rely so heavily on snapshots! It's way better to try and inspect the container using methods available on testing-library to check on the various components created in the render. I've done that in the new test added in this PR by inspecting the `bottom-center` container and checking that it includes a notification and the `top-center` container does not.

> Also note: I couldn't find any info on `smallScreenBreakpoint` very easily when investigating why my notifications weren't appearing in the desired container. You may want to add a section to the README so that the breakpoint system can be more easily discovered. (There's only one reference to the prop in any markdown files).

### Checklist
- [x] I ran the tests with `npm run test` 
- [x] I added tests for the bug I fixed (if applicable)
- [x] I updated the README or the DOCUMENTATION (if applicable)
- [ ] I updated the demo (if applicable)
- [ ] I verified my changes on all browsers listed below:
  - [ ] Chrome
  - [ ] Safari
  - [ ] Firefox
  - [ ] IE 10+
  - [ ] Edge
  - [ ] Opera

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/reapop/348)
<!-- Reviewable:end -->
