### PR TITLE
NotificationsSystem::notifications field, being an instance of Map, can also yield undefined as a result of Map.get('notifications')

### DIFF
--- a/src/components/NotificationsSystem.tsx
+++ b/src/components/NotificationsSystem.tsx
@@ -9,7 +9,7 @@ import NotificationsContainer from './NotificationsContainer'
 export type DismissNotification = (id: string) => void
 
 export type Props = {
-    notifications: Notification[]
+    notifications: Notification[] | undefined
     dismissNotification: DismissNotification
     smallScreenBreakpoint?: number
     components?: ComponentContextType


### PR DESCRIPTION
Redux states are an implementation of JS' Map. As such, statement such as `state.get('notifications')` will yield `Notification[] | undefined` result. This needs to be explicitly stated in typing, otherwise `strictNullChecks = true` flag will cause an unnecessary headache. See https://github.com/microsoft/TypeScript/issues/9619

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/reapop/375)
<!-- Reviewable:end -->
