### PR TITLE
fix: prevent state mutation when upserting a notification

### DIFF
--- a/src/reducers/notifications/reducer.ts
+++ b/src/reducers/notifications/reducer.ts
@@ -1,6 +1,7 @@
 import {NotificationAction} from './constants'
 import {DismissNotificationAction, NotificationActions, UpsertNotificationAction} from './actions'
 import {Notification} from './types'
+import {clone} from '../../utils'
 
 type InitReduxAction = {
     type: string
@@ -12,7 +13,7 @@ const notificationsReducer = () => {
     return (state = INITIAL_STATE, action: NotificationActions | InitReduxAction): Notification[] => {
         switch (action.type) {
             case NotificationAction.UpsertNotification: {
-                const payload = (action as UpsertNotificationAction).payload
+                const payload = clone((action as UpsertNotificationAction).payload)
                 if (~state.findIndex((notif) => notif.id === payload.id)) {
                     return state.map((notif) => (notif.id === payload.id ? payload : notif))
                 }

--- a/src/reducers/notifications/tests/reducer.spec.ts
+++ b/src/reducers/notifications/tests/reducer.spec.ts
@@ -28,7 +28,11 @@ describe('notificationsReducer', () => {
 
     describe('UpsertNotification', () => {
         it('should add notification', () => {
-            expect(reducer(undefined, notify({id: '1'}))).toMatchSnapshot()
+            const action = notify({id: '1'})
+            const newState = reducer(undefined, action)
+
+            expect(newState[0]).not.toBe(action.payload)
+            expect(newState).toMatchSnapshot()
         })
 
         it('should update notification', () => {
@@ -45,7 +49,10 @@ describe('notificationsReducer', () => {
             notification.allowHTML = true
 
             const action = notify({id: '1', dismissible: true})
-            expect(reducer(initialState, action)).toMatchSnapshot()
+            const newState = reducer(initialState, action)
+
+            expect(newState[0]).not.toBe(action.payload)
+            expect(newState).toMatchSnapshot()
         })
     })
 


### PR DESCRIPTION
### Related issues: #394 
### Changes
- fix: prevent state mutation when upserting a notification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/reapop/426)
<!-- Reviewable:end -->
