### PR TITLE
Simple custom component injection

### DIFF
--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const Notification = (props: Props) => {
     const {notification, dismissNotification: dismiss, theme, components} = props
-    const {id, title, message, dismissible, showDismissButton, buttons, allowHTML, image} = notification
+    const {id, title, message, dismissible, showDismissButton, buttons, allowHTML, image, customComponent} = notification
     const wrapperClassname = classnames.notification(notification)
     const wrapperStyles = theme ? theme.notification(notification) : {}
     const metaStyles = theme ? theme.notificationMeta(notification) : {}
@@ -52,6 +52,7 @@ const Notification = (props: Props) => {
                             {title}
                         </h4>
                     ))}
+                {customComponent}
                 {message &&
                     (allowHTML ? (
                         <p

--- a/src/reducers/notifications/types.ts
+++ b/src/reducers/notifications/types.ts
@@ -1,4 +1,5 @@
 import {POSITIONS, STATUSES} from '../../constants'
+import { FC } from "react";
 
 export interface NotificationButton {
     name: string
@@ -23,6 +24,7 @@ export interface Notification {
     onDismiss?: (...args: any[]) => void
     showDismissButton?: boolean
     allowHTML?: boolean
+    customComponent?: FC
     [index: string]: any
 }
 


### PR DESCRIPTION
### Related issues: <!-- If applicable: reference any related issues. E.g: #4515   -->  
### Changes
I've made some simple changes to the Notification component to make it render any arbitrary custom component.
What i've done is basically editing the notification type for an extra React Functional Component property, then in the notification component i just put it straight in render, right before the message object, since it is a nullable type an wont interfer with the component rendering if the "user" doesn't pass any customComponent in the notifcation object.

This is just a simple change i wanted to propose, I'm not going to test anything more until i get some form of consent on my solution.

### Checklist
- [ ] I ran the tests with `npm run test` 
- [ ] I added tests for the bug I fixed (if applicable)
- [ ] I updated the README or the DOCUMENTATION (if applicable)
- [ ] I updated the demo (if applicable)
- [ ] I verified my changes on all browsers listed below:
  - [x] Chrome
  - [ ] Safari
  - [x] Firefox
  - [ ] IE 10+
  - [x] Edge
  - [ ] Opera

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/reapop/430)
<!-- Reviewable:end -->
